### PR TITLE
Fix fallback stylesheet reference for minified Bootstrap CSS

### DIFF
--- a/src/live.asp.net/Views/Shared/_Layout.cshtml
+++ b/src/live.asp.net/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     </environment>
     <environment names="Staging,Production">
         <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.5/css/bootstrap.min.css"
-              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.css"
+              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
               asp-fallback-test-class="invisible"
               asp-fallback-test-property="visibility"
               asp-fallback-test-value="hidden" />


### PR DESCRIPTION
The fallback is for production/staging environment where all resources
in the project are used in minified versions. This commit fixes
reference to point to a minified version of Bootstrap CSS.

I've already signed CLA
Thanks!
