### PR TITLE
Add missing robots.txt file to project root

### DIFF
--- a/src/live.asp.net/wwwroot/robots.txt
+++ b/src/live.asp.net/wwwroot/robots.txt
@@ -1,0 +1,5 @@
+# www.robotstxt.org/
+
+# Allow crawling of all content
+User-agent: *
+Disallow:


### PR DESCRIPTION
This commit adds missing robots.txt file to web site root.
The content of robots.txt file is taken from H5BP project:
http://git.io/vJSES

AFAIK I don't need to provide middleware as it is already covered by static files:
https://github.com/aspnet/StaticFiles/blob/545fa9e70a8308097554dc56ed0e82feb309bb34/src/Microsoft.AspNet.StaticFiles/FileExtensionContentTypeProvider.cs#L318

Thanks!
