### PR TITLE
Add semantic importance and meaning to show badges/labels

### DIFF
--- a/src/live.asp.net/Views/Home/Index.cshtml
+++ b/src/live.asp.net/Views/Home/Index.cshtml
@@ -18,11 +18,11 @@
                 ASP.NET Community Standup
                 @if (Model.IsOnAir)
                 {
-                    <span class="label label-danger">ON AIR</span>
+                    <span class="label label-danger"><strong>ON AIR</strong></span>
                 }
                 else if (Model.HasAdminMessage)
                 {
-                    <span class="label label-warning">STANDBY</span>
+                    <span class="label label-warning"><strong>STANDBY</strong></span>
                 }
             </h1>
             @if (Model.HasAdminMessage)


### PR DESCRIPTION
This commits adds HTML5 semantics to show StandBy/OnAir badges.
They will be now differently rendered or spoken - as intended by visual
clues.

There is no visual change in how visual clues are rendered by BS CSS, as `strong` tag has the same weight in BS css as `label` class. The change will be seen in other readers or heard in readers:

![20150809222127](https://cloud.githubusercontent.com/assets/14539/9156779/f584e9d6-3ee5-11e5-9cac-3a791754b791.jpg)
![20150809221833](https://cloud.githubusercontent.com/assets/14539/9156780/f588c4ac-3ee5-11e5-881f-94ce06683a2a.jpg)
![20150809222259](https://cloud.githubusercontent.com/assets/14539/9156783/fd87f240-3ee5-11e5-9dd3-c449249e68c4.jpg)

Thanks!
