### PR TITLE
Environment and Framework tag helpers.

### DIFF
--- a/src/live.asp.net/TagHelpers/EnvironmentInformationTagHelper.cs
+++ b/src/live.asp.net/TagHelpers/EnvironmentInformationTagHelper.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNet.Hosting;
+using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+
+namespace live.asp.net.TagHelpers
+{
+    [HtmlTargetElement("environment-info", TagStructure = TagStructure.WithoutEndTag)]
+    public class EnvironmentInformationTagHelper : TagHelper
+    {
+        private readonly IHostingEnvironment HostingEnvironment;
+
+        public string Label { get; set; } = "Environment";
+        public EnvironmentInformationTagHelper(IHostingEnvironment env)
+        {
+            HostingEnvironment = env;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (string.IsNullOrWhiteSpace(Label))
+                output.Content.SetContent(HostingEnvironment.EnvironmentName);
+            else
+                output.Content.SetContent($"{Label}: {HostingEnvironment.EnvironmentName}");
+            output.TagName = null;
+        }
+    }
+}

--- a/src/live.asp.net/TagHelpers/FrameworkInformationTagHelper.cs
+++ b/src/live.asp.net/TagHelpers/FrameworkInformationTagHelper.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+using Microsoft.Dnx.Runtime;
+
+namespace live.asp.net.TagHelpers
+{
+    [HtmlTargetElement("framework-info", TagStructure = TagStructure.WithoutEndTag)]
+    public class FrameworkInformationTagHelper : TagHelper
+    {
+        private readonly IApplicationEnvironment ApplicationEnvironment;
+
+        public string Label { get; set; } = "Framework";
+        public FrameworkInformationTagHelper(IApplicationEnvironment app)
+        {
+            ApplicationEnvironment = app;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (string.IsNullOrWhiteSpace(Label))
+                output.Content.SetContent(ApplicationEnvironment.RuntimeFramework.ToString());
+            else
+                output.Content.SetContent($"{Label}: {ApplicationEnvironment.RuntimeFramework.ToString()}");
+            output.TagName = null;
+        }
+    }
+}

--- a/src/live.asp.net/TagHelpers/HtmlCommentTagHelper.cs
+++ b/src/live.asp.net/TagHelpers/HtmlCommentTagHelper.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+
+namespace live.asp.net.TagHelpers
+{
+    [HtmlTargetElement("*", Attributes ="commented")]
+    public class HtmlCommentTagHelper : TagHelper
+    {
+        private const string StartHtmlComment = "<!-- ";
+        private const string EndHtmlComment = " -->";
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.PreContent.AppendEncoded(StartHtmlComment);
+            output.PostContent.AppendEncoded(EndHtmlComment);
+            output.TagName = null;
+        }
+    }
+}

--- a/src/live.asp.net/TagHelpers/HtmlCommentTagHelper.cs
+++ b/src/live.asp.net/TagHelpers/HtmlCommentTagHelper.cs
@@ -2,7 +2,6 @@
 
 namespace live.asp.net.TagHelpers
 {
-    [HtmlTargetElement("*", Attributes ="commented")]
     public class HtmlCommentTagHelper : TagHelper
     {
         private const string StartHtmlComment = "<!-- ";

--- a/src/live.asp.net/Views/Shared/_Layout.cshtml
+++ b/src/live.asp.net/Views/Shared/_Layout.cshtml
@@ -26,7 +26,7 @@
     @RenderSection("PreContent", required: false)
     <div class="container body-content">
         @RenderBody()
-        
+
         <footer>
             <div class="row">
                 <div class="col-md-6">
@@ -58,5 +58,5 @@
     @RenderSection("scripts", required: false)
 </body>
 </html>
-<environment-info commented />
-<framework-info commented />
+<html-comment><environment-info /></html-comment>
+<html-comment><framework-info /></html-comment>

--- a/src/live.asp.net/Views/Shared/_Layout.cshtml
+++ b/src/live.asp.net/Views/Shared/_Layout.cshtml
@@ -1,6 +1,4 @@
-﻿@inject Microsoft.AspNet.Hosting.IHostingEnvironment HostingEnvironment
-@inject Microsoft.Dnx.Runtime.IApplicationEnvironment ApplicationEnvironment
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -60,5 +58,5 @@
     @RenderSection("scripts", required: false)
 </body>
 </html>
-<!-- Environment: @HostingEnvironment.EnvironmentName -->
-<!-- Framework: @ApplicationEnvironment.RuntimeFramework -->
+<environment-info commented />
+<framework-info commented />


### PR DESCRIPTION
Replaced Framework and Environment info from inject to Tag Helpers because Tag Helpers are cool!

I was doing this just for fun, maybe it's too much for a simple comment on the layout page. Feel free to reject this commit if you think it doesn't apply.
