### PR TITLE
Use FileInfo.Length instead of MemoryStream.Length

### DIFF
--- a/src/live.asp.net/Program.cs
+++ b/src/live.asp.net/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 
 namespace live.asp.net

--- a/src/live.asp.net/Services/AppStart.cs
+++ b/src/live.asp.net/Services/AppStart.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace live.asp.net.Services
+{
+    public class AppStart : IStartupFilter
+    {
+        private readonly IApplicationLifetime _appLifetime;
+        private readonly CachedWebRootFileProvider _cachedWebRoot;
+        private readonly TelemetryClient _telemetry;
+
+        public AppStart(IApplicationLifetime appLifetime, TelemetryClient telemetry, CachedWebRootFileProvider cachedWebRoot)
+        {
+            _appLifetime = appLifetime;
+            _telemetry = telemetry;
+            _cachedWebRoot = cachedWebRoot;
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+        {
+            // Enable tracking of application start/stop to Application Insights
+            if (_telemetry.IsEnabled())
+            {
+                _appLifetime.ApplicationStarted.Register(() =>
+                {
+                    var startedEvent = new EventTelemetry("Application Started");
+                    _telemetry.TrackEvent(startedEvent);
+                });
+                _appLifetime.ApplicationStopping.Register(() =>
+                {
+                    var startedEvent = new EventTelemetry("Application Stopping");
+                    _telemetry.TrackEvent(startedEvent);
+                });
+                _appLifetime.ApplicationStopped.Register(() =>
+                {
+                    var stoppedEvent = new EventTelemetry("Application Stopped");
+                    _telemetry.TrackEvent(stoppedEvent);
+                    _telemetry.Flush();
+
+                    // Allow some time for flushing before shutdown.
+                    Thread.Sleep(1000);
+                });
+            }
+
+            // Call next now so that the ILoggerFactory by Startup.Configure is configured before we go any further
+            next(app);
+
+            // Prime the cached web root file provider for static file serving
+            _cachedWebRoot.PrimeCache();
+        };
+    }
+}

--- a/src/live.asp.net/Services/ApplicationInsightsServiceOptionsSetup.cs
+++ b/src/live.asp.net/Services/ApplicationInsightsServiceOptionsSetup.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace live.asp.net.Services
+{
+    public class ApplicationInsightsServiceOptionsSetup : IConfigureOptions<ApplicationInsightsServiceOptions>
+    {
+        private readonly IDeploymentEnvironment _deploymentEnvironment;
+
+        public ApplicationInsightsServiceOptionsSetup(IDeploymentEnvironment deploymentEnvironment)
+        {
+            _deploymentEnvironment = deploymentEnvironment;
+        }
+
+        public void Configure(ApplicationInsightsServiceOptions options)
+        {
+            options.ApplicationVersion = _deploymentEnvironment.DeploymentId.Substring(0, 7);
+        }
+    }
+}

--- a/src/live.asp.net/Services/AzureStorageLiveShowDetailsService.cs
+++ b/src/live.asp.net/Services/AzureStorageLiveShowDetailsService.cs
@@ -90,20 +90,21 @@ namespace live.asp.net.Services
             {
                 if (_telemetry.IsEnabled())
                 {
+                    var duration = Timing.GetDuration(started);
                     var dependency = new DependencyTelemetry
                     {
                         Type = "Storage",
-                        Target = blockBlob.StorageUri.PrimaryUri.ToString(),
+                        Target = blockBlob.StorageUri.PrimaryUri.Host,
                         Name = blockBlob.Name,
                         Data = "Download",
                         Timestamp = DateTimeOffset.UtcNow,
-                        Duration = Timing.GetDuration(started),
+                        Duration = duration,
                         Success = fileContents != null
                     };
                     dependency.Metrics.Add("Size", fileContents.Length);
+                    dependency.Properties.Add("Storage Uri", blockBlob.StorageUri.PrimaryUri.ToString());
                     _telemetry.TrackDependency(dependency);
                 }
-                //_telemtry.TrackDependency("Azure.BlobStorage", "DownloadTextAsync", downloadStarted, DateTimeOffset.UtcNow - downloadStarted, true);
             }
 
             return JsonConvert.DeserializeObject<LiveShowDetails>(fileContents);
@@ -134,6 +135,7 @@ namespace live.asp.net.Services
             {
                 if (_telemetry.IsEnabled())
                 {
+                    var duration = Timing.GetDuration(started);
                     var dependency = new DependencyTelemetry
                     {
                         Type = "Storage",
@@ -141,12 +143,11 @@ namespace live.asp.net.Services
                         Name = blockBlob.Name,
                         Data = "Upload",
                         Timestamp = DateTimeOffset.UtcNow,
-                        Duration = Timing.GetDuration(started),
+                        Duration = duration,
                         Success = succeeded
                     };
                     dependency.Metrics.Add("Size", fileContents.Length);
                     _telemetry.TrackDependency(dependency);
-                    //_telemetry.TrackDependency("Azure.BlobStorage", "UploadTextAsync", uploadStarted, DateTimeOffset.UtcNow - uploadStarted, true);
                 }
             }
         }

--- a/src/live.asp.net/Services/CachedWebRootFileProvider.cs
+++ b/src/live.asp.net/Services/CachedWebRootFileProvider.cs
@@ -51,17 +51,17 @@ namespace live.asp.net.Services
 
             foreach (var fileInfo in GetDirectoryContents(currentPath))
             {
-                var subpath = prefix + fileInfo.Name;
                 if (fileInfo.IsDirectory)
                 {
-                    var cacheSize = PrimeCacheImpl(subpath);
+                    var cacheSize = PrimeCacheImpl(prefix + fileInfo.Name);
                     cacheEntriesAdded += cacheSize.Item1;
                     bytesCached += cacheSize.Item2;
                 }
                 else
                 {
-                    var info = GetFileInfo(subpath);
-                    bytesCached += info.Length;
+                    var stream = GetFileInfo(prefix + fileInfo.Name).CreateReadStream();
+                    bytesCached += stream.Length;
+                    stream.Dispose();
                     cacheEntriesAdded++;
                 }
             }

--- a/src/live.asp.net/Services/CachedWebRootFileProvider.cs
+++ b/src/live.asp.net/Services/CachedWebRootFileProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting;
@@ -16,7 +15,6 @@ namespace live.asp.net.Services
     public class CachedWebRootFileProvider : IFileProvider
     {
         private static readonly int _fileSizeLimit = 256 * 1024; // bytes
-        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 
         private readonly ILogger<CachedWebRootFileProvider> _logger;
         private readonly IFileProvider _fileProvider;
@@ -31,16 +29,14 @@ namespace live.asp.net.Services
 
         public void PrimeCache()
         {
-            var startTimestamp = _logger.IsEnabled(LogLevel.Information) ? Stopwatch.GetTimestamp() : 0;
+            var started = _logger.IsEnabled(LogLevel.Information) ? Timing.GetTimestamp() : 0;
 
             _logger.LogInformation("Priming the cache");
             var cacheSize = PrimeCacheImpl("/");
 
-            if (startTimestamp != 0)
+            if (started != 0)
             {
-                var currentTimestamp = Stopwatch.GetTimestamp();
-                var elapsed = new TimeSpan((long)(TimestampToTicks * (currentTimestamp - startTimestamp)));
-                _logger.LogInformation("Cache primed with {cacheEntriesCount} entries totalling {cacheEntriesSizeBytes} bytes in {elapsed}", cacheSize.Item1, cacheSize.Item2, elapsed);
+                _logger.LogInformation("Cache primed with {cacheEntriesCount} entries totalling {cacheEntriesSizeBytes} bytes in {elapsed}", cacheSize.Item1, cacheSize.Item2, Timing.GetDuration(started));
             }
         }
 

--- a/src/live.asp.net/Services/CachedWebRootFileProvider.cs
+++ b/src/live.asp.net/Services/CachedWebRootFileProvider.cs
@@ -51,17 +51,17 @@ namespace live.asp.net.Services
 
             foreach (var fileInfo in GetDirectoryContents(currentPath))
             {
+                var subpath = prefix + fileInfo.Name;
                 if (fileInfo.IsDirectory)
                 {
-                    var cacheSize = PrimeCacheImpl(prefix + fileInfo.Name);
+                    var cacheSize = PrimeCacheImpl(subpath);
                     cacheEntriesAdded += cacheSize.Item1;
                     bytesCached += cacheSize.Item2;
                 }
                 else
                 {
-                    var stream = GetFileInfo(prefix + fileInfo.Name).CreateReadStream();
-                    bytesCached += stream.Length;
-                    stream.Dispose();
+                    var info = GetFileInfo(subpath);
+                    bytesCached += info.Length;
                     cacheEntriesAdded++;
                 }
             }

--- a/src/live.asp.net/Services/CachedWebRootFileProvider.cs
+++ b/src/live.asp.net/Services/CachedWebRootFileProvider.cs
@@ -55,17 +55,17 @@ namespace live.asp.net.Services
 
             foreach (var fileInfo in GetDirectoryContents(currentPath))
             {
+                var subpath = prefix + fileInfo.Name;
                 if (fileInfo.IsDirectory)
                 {
-                    var cacheSize = PrimeCacheImpl(prefix + fileInfo.Name);
+                    var cacheSize = PrimeCacheImpl(subpath);
                     cacheEntriesAdded += cacheSize.Item1;
                     bytesCached += cacheSize.Item2;
                 }
                 else
                 {
-                    var stream = GetFileInfo(prefix + fileInfo.Name).CreateReadStream();
-                    bytesCached += stream.Length;
-                    stream.Dispose();
+                    var info = GetFileInfo(subpath);
+                    bytesCached += info.Length;
                     cacheEntriesAdded++;
                 }
             }

--- a/src/live.asp.net/Services/EnvironmentTelemetryInitializer.cs
+++ b/src/live.asp.net/Services/EnvironmentTelemetryInitializer.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Hosting;
+
+namespace live.asp.net.Services
+{
+    /// <summary>
+    /// Adds the ASP.NET Core environment name to all tracked telemetry calls.
+    /// </summary>
+    public class EnvironmentTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly IHostingEnvironment _hostingEnv;
+
+        public EnvironmentTelemetryInitializer(IHostingEnvironment hostingEnvironment)
+        {
+            _hostingEnv = hostingEnvironment;
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            var telemetryWithProperties = telemetry as ISupportProperties;
+            if (telemetryWithProperties != null)
+            {
+                telemetryWithProperties.Properties.Add("Environment name", _hostingEnv.EnvironmentName);
+            }
+        }
+    }
+}

--- a/src/live.asp.net/Services/ServiceExtensions.cs
+++ b/src/live.asp.net/Services/ServiceExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace live.asp.net.Services
+{
+    public static class ServiceExtensions
+    {
+        public static IServiceCollection AddCachedWebRoot(this IServiceCollection services)
+        {
+            // Turn off compaction on memory pressure as it results in things being evicted during the priming of the
+            // cache on application start.
+            services.AddMemoryCache(options => options.CompactOnMemoryPressure = false);
+            services.AddSingleton<CachedWebRootFileProvider>();
+            services.AddSingleton<IConfigureOptions<StaticFileOptions>, StaticFileOptionsSetup>();
+            return services;
+        }
+    }
+}

--- a/src/live.asp.net/Services/StaticFileOptionsSetup.cs
+++ b/src/live.asp.net/Services/StaticFileOptionsSetup.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
+
+namespace live.asp.net.Services
+{
+    public class StaticFileOptionsSetup : IConfigureOptions<StaticFileOptions>
+    {
+        private readonly CachedWebRootFileProvider _cachedWebRoot;
+
+        public StaticFileOptionsSetup(CachedWebRootFileProvider cachedWebRoot)
+        {
+            _cachedWebRoot = cachedWebRoot;
+        }
+
+        public void Configure(StaticFileOptions options)
+        {
+            options.FileProvider = _cachedWebRoot;
+        }
+    }
+}

--- a/src/live.asp.net/Services/YouTubeShowsService.cs
+++ b/src/live.asp.net/Services/YouTubeShowsService.cs
@@ -89,24 +89,7 @@ namespace live.asp.net.Services
                 }
                 finally
                 {
-                    if (_telemetry.IsEnabled())
-                    {
-                        var duration = Timing.GetDuration(started);
-                        var dependency = new DependencyTelemetry
-                        {
-                            Type = "HTTP",
-                            Target = client.BaseUri,
-                            Name = listRequest.RestPath,
-                            Data = listRequest.CreateRequest().RequestUri.ToString(),
-                            Timestamp = DateTimeOffset.UtcNow,
-                            Duration = duration,
-                            Success = playlistItems != null
-                        };
-                        dependency.Properties.Add("HTTP Method", listRequest.HttpMethod);
-                        dependency.Properties.Add("Event Id", playlistItems.EventId);
-                        dependency.Properties.Add("Total Results", (playlistItems.PageInfo.TotalResults ?? 0).ToString());
-                        _telemetry.TrackDependency(dependency);
-                    }
+                    TrackDependency(client.BaseUri, listRequest, playlistItems, started);
                 }
 
                 var result = new ShowList();
@@ -128,6 +111,28 @@ namespace live.asp.net.Services
                 }
 
                 return result;
+            }
+        }
+
+        private void TrackDependency(string urlHost, PlaylistItemsResource.ListRequest listRequest, PlaylistItemListResponse playlistItems, long started)
+        {
+            if (_telemetry.IsEnabled())
+            {
+                var duration = Timing.GetDuration(started);
+                var dependency = new DependencyTelemetry
+                {
+                    Type = "HTTP",
+                    Target = urlHost,
+                    Name = listRequest.RestPath,
+                    Data = listRequest.CreateRequest().RequestUri.ToString(),
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Duration = duration,
+                    Success = playlistItems != null
+                };
+                dependency.Properties.Add("HTTP Method", listRequest.HttpMethod);
+                dependency.Properties.Add("Event Id", playlistItems.EventId);
+                dependency.Properties.Add("Total Results", (playlistItems.PageInfo.TotalResults ?? 0).ToString());
+                _telemetry.TrackDependency(dependency);
             }
         }
 

--- a/src/live.asp.net/Services/YouTubeShowsService.cs
+++ b/src/live.asp.net/Services/YouTubeShowsService.cs
@@ -114,15 +114,17 @@ namespace live.asp.net.Services
             }
         }
 
-        private void TrackDependency(string urlHost, PlaylistItemsResource.ListRequest listRequest, PlaylistItemListResponse playlistItems, long started)
+        private void TrackDependency(string url, PlaylistItemsResource.ListRequest listRequest, PlaylistItemListResponse playlistItems, long started)
         {
             if (_telemetry.IsEnabled())
             {
+                Uri uri = null;
+                Uri.TryCreate(url, UriKind.Absolute, out uri);
                 var duration = Timing.GetDuration(started);
                 var dependency = new DependencyTelemetry
                 {
                     Type = "HTTP",
-                    Target = urlHost,
+                    Target = uri?.Host ?? url,
                     Name = listRequest.RestPath,
                     Data = listRequest.CreateRequest().RequestUri.ToString(),
                     Timestamp = DateTimeOffset.UtcNow,

--- a/src/live.asp.net/Services/YouTubeShowsService.cs
+++ b/src/live.asp.net/Services/YouTubeShowsService.cs
@@ -91,6 +91,7 @@ namespace live.asp.net.Services
                 {
                     if (_telemetry.IsEnabled())
                     {
+                        var duration = Timing.GetDuration(started);
                         var dependency = new DependencyTelemetry
                         {
                             Type = "HTTP",
@@ -98,12 +99,14 @@ namespace live.asp.net.Services
                             Name = listRequest.RestPath,
                             Data = listRequest.CreateRequest().RequestUri.ToString(),
                             Timestamp = DateTimeOffset.UtcNow,
-                            Duration = Timing.GetDuration(started),
+                            Duration = duration,
                             Success = playlistItems != null
                         };
+                        dependency.Properties.Add("HTTP Method", listRequest.HttpMethod);
+                        dependency.Properties.Add("Event Id", playlistItems.EventId);
+                        dependency.Properties.Add("Total Results", (playlistItems.PageInfo.TotalResults ?? 0).ToString());
                         _telemetry.TrackDependency(dependency);
                     }
-                    //_telemetry.TrackDependency("YouTube.PlayListItemsApi", "List", requestStart, DateTimeOffset.UtcNow - requestStart, true);
                 }
 
                 var result = new ShowList();

--- a/src/live.asp.net/Startup.cs
+++ b/src/live.asp.net/Startup.cs
@@ -4,14 +4,15 @@
 using System.Security.Claims;
 using live.asp.net.Formatters;
 using live.asp.net.Services;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace live.asp.net
@@ -64,6 +65,7 @@ namespace live.asp.net
             services.AddScoped<IShowsService, YouTubeShowsService>();
 
             services.AddSingleton<IDeploymentEnvironment, DeploymentEnvironment>();
+            services.AddSingleton<IConfigureOptions<ApplicationInsightsServiceOptions>, ApplicationInsightsServiceOptionsSetup>();
 
             if (string.IsNullOrEmpty(Configuration["AppSettings:AzureStorageConnectionString"]))
             {

--- a/src/live.asp.net/Timing.cs
+++ b/src/live.asp.net/Timing.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace live.asp.net
+{
+    public static class Timing
+    {
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        public static long GetTimestamp() => Stopwatch.GetTimestamp();
+
+        public static TimeSpan GetDuration(long start) => GetDuration(start, Stopwatch.GetTimestamp());
+
+        public static TimeSpan GetDuration(long start, long end) => new TimeSpan((long)(TimestampToTicks * (end - start)));
+    }
+}

--- a/src/live.asp.net/Views/Shared/_AnalyticsHead.cshtml
+++ b/src/live.asp.net/Views/Shared/_AnalyticsHead.cshtml
@@ -16,4 +16,10 @@
     </script>
 
     @Html.Raw(AppInsightsJs.FullScript)
+    @if (User.Identity.IsAuthenticated)
+    {
+        <script>
+            appInsights.setAuthenticatedUserContext("@User.Identity.Name.Replace("\\", "\\\\")".replace(/[,;=| ]+/g, "_"));
+        </script>
+    }
 </environment>

--- a/src/live.asp.net/Views/Shared/_Layout.cshtml
+++ b/src/live.asp.net/Views/Shared/_Layout.cshtml
@@ -62,7 +62,7 @@
 </body>
 </html>
 <cache>
-<!-- ViewType: @GetType().FullName -->
+<!-- ViewType: @GetType().AssemblyQualifiedName -->
 <!-- Environment: @HostingEnvironment.EnvironmentName -->
 <!-- Application: @Microsoft.Extensions.PlatformAbstractions.PlatformServices.Default.Application.ApplicationName, @Microsoft.Extensions.PlatformAbstractions.PlatformServices.Default.Application.ApplicationVersion -->
 <!-- Deployment: @DeploymentEnvironment.DeploymentId -->


### PR DESCRIPTION
This pull request add a small fix to avoid object allocation of MemoryStream on getting information about file size. /cc @DamianEdwards 