### PR TITLE
Fix year in footer copyright

### DIFF
--- a/src/live.asp.net/Views/Shared/_Layout.cshtml
+++ b/src/live.asp.net/Views/Shared/_Layout.cshtml
@@ -34,7 +34,7 @@
             <div class="row">
                 <div class="col-md-6">
                     <p>
-                        &copy; 2015 Microsoft. All rights reserved.
+                        &copy; @DateTime.Now.Year Microsoft. All rights reserved.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
There was still a 2015 year in footer copyright.